### PR TITLE
Add Jenkins CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # JAX bindings to FINUFFT
 
+[![GitHub Tests](https://github.com/flatironinstitute/jax-finufft/actions/workflows/tests.yml/badge.svg)](https://github.com/flatironinstitute/jax-finufft/actions/workflows/tests.yml)
+[![Jenkins Tests](https://jenkins.flatironinstitute.org/buildStatus/icon?job=jax-finufft%2Fmain)](https://jenkins.flatironinstitute.org/job/jax-finufft/view/change-requests/job/main/)
+
 This package provides a [JAX](https://github.com/google/jax) interface to (a
 subset of) the [Flatiron Institute Non-uniform Fast Fourier Transform (FINUFFT)
 library](https://github.com/flatironinstitute/finufft). Take a look at the

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,8 @@
+FROM nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    python3 \
+    python3-pip \
+    git \
+    libfftw3-dev

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
         stage('CPU Tests') {
             environment {
                 JAX_PLATFORMS = "cpu"
-                OMP_NUM_THREADS = "1"
+                OMP_NUM_THREADS = "4"
             }
             steps {
                 sh 'python3 -m pytest -v tests/'
@@ -32,7 +32,7 @@ pipeline {
         stage('GPU Tests') {
             environment {
                 JAX_PLATFORMS = "cuda"
-                OMP_NUM_THREADS = "1"
+                OMP_NUM_THREADS = "4"
             }
             steps {
                 sh 'python3 -m pytest -v tests/'

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,0 +1,42 @@
+pipeline {
+    agent {
+        dockerfile {
+            filename 'ci/Dockerfile'
+            args '--gpus 1'
+            label 'docker && v100'
+        }
+    }
+    options {
+        timeout(time: 1, unit: 'HOURS')
+    }
+    environment {
+        HOME = "$WORKSPACE"
+    }
+    stages {
+        stage('Build') {
+            steps {
+                sh 'python3 -m pip install -U pip'
+                sh 'python3 -m pip install "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html'
+                sh 'python3 -m pip install -v .[test]'
+            }
+        }
+        stage('CPU Tests') {
+            environment {
+                JAX_PLATFORMS = "cpu"
+                OMP_NUM_THREADS = "1"
+            }
+            steps {
+                sh 'python3 -m pytest -v tests/'
+            }
+        }
+        stage('GPU Tests') {
+            environment {
+                JAX_PLATFORMS = "cuda"
+                OMP_NUM_THREADS = "1"
+            }
+            steps {
+                sh 'python3 -m pytest -v tests/'
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a Jenkins CI config to run the GPU (and CPU) tests on the FI Jenkins platform. The test are currently passing and the output can be seen here: https://jenkins.flatironinstitute.org/job/jax-finufft/

There's a few TODOs, like figuring out the right number of OpenMP threads and getting the GitHub webhooks installed, but overall I think this is pretty close to done!