### PR TITLE
Remove `backend_config` arg in CPU lowering

### DIFF
--- a/src/jax_finufft/lowering.py
+++ b/src/jax_finufft/lowering.py
@@ -130,7 +130,6 @@ def lowering(platform, ctx, source, *points, output_shape, iflag, eps):
             ],
             # Reverse points because backend uses Fortran order
             operands=[opaque_arg, source, *points[::-1]],
-            backend_config=opaque,
             operand_layouts=default_layouts(
                 opaque_shape, source_shape, *points_shape[::-1]
             ),

--- a/tests/ops_test.py
+++ b/tests/ops_test.py
@@ -313,7 +313,7 @@ def test_issue14():
 
 def test_issue37():
     if jax.default_backend() != "cpu":
-        pytest.skip("1D transforms not implemented on GPU")
+        pytest.xfail("TODO: this test currently fails on the GPU")
 
     @jax.jit
     @partial(jax.vmap, in_axes=(0, 0, None))

--- a/tests/ops_test.py
+++ b/tests/ops_test.py
@@ -318,7 +318,6 @@ def test_issue37():
     @jax.jit
     @partial(jax.vmap, in_axes=(0, 0, None))
     def cconv_test(f, xs, kernel):
-
         # f.shape = (n_grid, in_features)
         # x.shape = (n_grid, ndim)
         # kernel.shape = (*k_grid, in_features, out_features)
@@ -327,10 +326,10 @@ def test_issue37():
         k_grid_shape = kernel.shape[:-2]
 
         f_ = f.transpose().astype(complex)
-        coords = [xs[...,i] for i in range(ndim)]
+        coords = [xs[..., i] for i in range(ndim)]
 
         f_hat = nufft1(k_grid_shape, f_, *coords, iflag=-1)
-        c_hat = jnp.einsum('a...,...ab->b...', f_hat, kernel)
+        c_hat = jnp.einsum("a...,...ab->b...", f_hat, kernel)
         return nufft2(c_hat, *coords, iflag=1)
 
     kernel = jnp.array(np.random.randn(32, 32, 32, 16, 16))

--- a/tests/ops_test.py
+++ b/tests/ops_test.py
@@ -336,4 +336,4 @@ def test_issue37():
     f = jnp.array(np.random.randn(8, 100, 16))
     x = jnp.array(np.random.uniform(low=-np.pi, high=np.pi, size=(8, 100, 3)))
 
-    fconv = cconv_test(f, x, kernel)
+    cconv_test(f, x, kernel)


### PR DESCRIPTION
Fixes the XLA compilation error in #37. (The GPU crash remains, will work on that next.)

Since we're passing `opaque` explicitly as an arg in the CPU backend, we don't want to also pass it as a `backend_config`. Doing so appears to cause a crash under some circumstances, presumably because the target CPU function is being called with args it didn't expect.

CC: @Matematija