### PR TITLE
Fix indexing of nupts for batched nufft (`n_tot > 1`)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.15...3.26)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C CXX)
 message(STATUS "Using CMake version: " ${CMAKE_VERSION})
 
+# for cuda-gdb and verbose PTXAS output
+# set(CMAKE_CUDA_FLAGS ${CMAKE_CUDA_FLAGS} "-g -G -Xptxas -v")
+
 # Workaround for LTO applied incorrectly to CUDA fatbin
 # https://github.com/pybind/pybind11/issues/4825
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)

--- a/lib/kernels.cc.cu
+++ b/lib/kernels.cc.cu
@@ -22,10 +22,11 @@ void run_nufft(int type, const NufftDescriptor<T> *descriptor, T *x, T *y, T *z,
   makeplan<T>(type, ndim, descriptor->n_k, descriptor->iflag, descriptor->n_transf,
               descriptor->eps, &plan, opts);
   for (int64_t index = 0; index < descriptor->n_tot; ++index) {
+    int64_t i = index * descriptor->n_j;
     int64_t j = index * descriptor->n_j * descriptor->n_transf;
     int64_t k = index * n_k * descriptor->n_transf;
 
-    setpts<T>(plan, descriptor->n_j, &(x[j]), y_index<ndim, T>(y, j), z_index<ndim, T>(z, j), 0,
+    setpts<T>(plan, descriptor->n_j, &(x[i]), y_index<ndim, T>(y, i), z_index<ndim, T>(z, i), 0,
               NULL, NULL, NULL);
 
     execute<T>(plan, &c[j], &F[k]);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ wheel.install-dir = "jax_finufft"
 minimum-version = "0.5"
 build-dir = "build/{wheel_tag}"
 
+# For debugging:
+# cmake.build-type = "Debug"
+# cmake.verbose = true
+# install.strip = false
+
 [tool.setuptools_scm]
 version_file = "src/jax_finufft/jax_finufft_version.py"
 

--- a/tests/ops_test.py
+++ b/tests/ops_test.py
@@ -322,8 +322,8 @@ def test_issue37():
         k_grid_shape = kernel.shape[:-2]
 
         f_ = f.astype(
-                {np.float32: np.complex64, np.float64: np.complex128}[f.dtype.type]
-            ).transpose()
+            {np.float32: np.complex64, np.float64: np.complex128}[f.dtype.type]
+        ).transpose()
         coords = [xs[..., i] for i in range(ndim)]
 
         f_hat = nufft1(k_grid_shape, f_, *coords, iflag=-1)

--- a/tests/ops_test.py
+++ b/tests/ops_test.py
@@ -312,10 +312,6 @@ def test_issue14():
 
 
 def test_issue37():
-    if jax.default_backend() != "cpu":
-        pytest.xfail("TODO: this test currently fails on the GPU")
-
-    @jax.jit
     @partial(jax.vmap, in_axes=(0, 0, None))
     def cconv_test(f, xs, kernel):
         # f.shape = (n_grid, in_features)
@@ -325,7 +321,9 @@ def test_issue37():
         ndim = xs.shape[-1]
         k_grid_shape = kernel.shape[:-2]
 
-        f_ = f.transpose().astype(complex)
+        f_ = f.astype(
+                {np.float32: np.complex64, np.float64: np.complex128}[f.dtype.type]
+            ).transpose()
         coords = [xs[..., i] for i in range(ndim)]
 
         f_hat = nufft1(k_grid_shape, f_, *coords, iflag=-1)
@@ -336,4 +334,10 @@ def test_issue37():
     f = jnp.array(np.random.randn(8, 100, 16))
     x = jnp.array(np.random.uniform(low=-np.pi, high=np.pi, size=(8, 100, 3)))
 
-    cconv_test(f, x, kernel)
+    a = cconv_test(f, x, kernel)
+    b = jax.jit(cconv_test)(f, x, kernel)
+
+    assert np.isfinite(a).all()
+    assert np.isfinite(b).all()
+
+    check_close(a, b)


### PR DESCRIPTION
jax-finufft has two levels of batching: an inner level where finufft does multiple transforms for the same set of NU points (`n_transf > 1`), and an outer level where jax-finufft does multiple transforms with different NU points (looping over `n_tot`).  Therefore the NU points arrays have shape `[n_tot, n_j]`, and the source array has shape `[n_tot, n_transf, n_j]`.  However, the NU points arrays were being indexed as if they had the latter shape.  This was leading to out-of-bounds memory accesses on the GPU when trying to use `n_tot > 1`, e.g. as a result of  `jax.vmap`.

This fixes the GPU runtime error in #37.

The submodule update points us at a more recent finufft.  We're still using at a fork while we wait for upstream work to finish, but this update brings us much closer to the current state of the upstream.  The fork also uses fewer threads per block in certain register-intensive 3D operations, which should fix CUDA errors about not enough resources.

CC @Matematija