### PR TITLE
Fixing #54

### DIFF
--- a/src/jax_finufft/ops.py
+++ b/src/jax_finufft/ops.py
@@ -97,6 +97,7 @@ def jvp(prim, args, tangents, *, output_shape, iflag, eps):
         k = np.arange(-np.floor(n / 2), np.floor((n - 1) / 2 + 1))
         k = k.reshape(shape)
         factor = 1j * iflag * k
+        dx = dx[:, None, :]
 
         if output_shape is None:
             scales.append(dx)

--- a/tests/ops_test.py
+++ b/tests/ops_test.py
@@ -286,7 +286,7 @@ def test_multi_transform():
         check_close(calc2[:, n], nufft2(f[:, n], x), rtol=1e-4)
 
 
-def test_issue14():
+def test_gh14():
     if jax.default_backend() != "cpu":
         pytest.skip("1D transforms not implemented on GPU")
 
@@ -311,7 +311,7 @@ def test_issue14():
     jax.grad(norm_nufft1, argnums=(1,))(c, x)
 
 
-def test_issue37():
+def test_gh37():
     @partial(jax.vmap, in_axes=(0, 0, None))
     def cconv_test(f, xs, kernel):
         # f.shape = (n_grid, in_features)
@@ -341,3 +341,23 @@ def test_issue37():
     assert np.isfinite(b).all()
 
     check_close(a, b)
+
+
+def test_gh54():
+    @jax.vmap
+    def aux(f, x):
+        f_hat = nufft1((32, 32, 32), f, *x, iflag=-1)
+        return jnp.real(f_hat).mean()
+
+    def test(f, x):
+        return aux(f, x).mean()
+
+    f = np.random.randn(8, 1000).astype(jnp.complex_)
+    x = np.random.randn(8, 3, 1000)
+
+    assert (
+        test(f, x).shape
+        == jax.jvp(partial(test, f), (x,), (jnp.ones_like(x),))[0].shape
+    )
+    assert jax.grad(test, argnums=0)(f, x).shape == f.shape
+    assert jax.grad(test, argnums=1)(f, x).shape == x.shape


### PR DESCRIPTION
The fix for #54 was pretty straightforward once I finally narrowed down where it was coming from. We didn't catch this before because we were foiled by NumPy/JAX broadcasting rules.

cc @lgarrison, @Matematija 