### PR TITLE
vendor: bump finufft to 2.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "finufft"]
 	path = vendor/finufft
-	url = https://github.com/lgarrison/finufft
+	url = https://github.com/flatironinstitute/finufft


### PR DESCRIPTION
Bumps the finufft dependency to the latest release version, which includes the fixes for the stream race conditions that we had previously been maintaining in our own fork. So now we're back to tracking the "real" repo, rather than a fork.

This version also includes improvements to CUDA error handling. @joseph-long, would you like to see if this gives a more informative error message for your crash?