### PR TITLE
installation: update readme and tweak dependencies

### DIFF
--- a/.github/workflows/gpu-build.yml
+++ b/.github/workflows/gpu-build.yml
@@ -30,7 +30,9 @@ jobs:
           python-version: 3.11
 
       - name: Install Python dependencies
-        run: python -m pip install -U pip
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U jax[cpu]
 
       - name: Compile the extension
         run: python -m pip install -v .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Build
         run: |
           python -m pip install -U pip
+          python -m pip install -U jax[cpu]
           python -m pip install -v .[test]
 
       - name: Run tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ message(STATUS "Using CMake version: " ${CMAKE_VERSION})
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
 
 # Enable CUDA if requested and available
-option(JAX_FINUFFT_USE_CUDA "Enable CUDA build if available" OFF)
+option(JAX_FINUFFT_USE_CUDA "Enable CUDA build" OFF)
 if(JAX_FINUFFT_USE_CUDA)
     include(CheckLanguage)
     check_language(CUDA)
@@ -19,7 +19,8 @@ if(JAX_FINUFFT_USE_CUDA)
         enable_language(CUDA)
         set(FINUFFT_USE_CUDA ON)
     else()
-        message(STATUS "No CUDA compiler found; compiling without GPU support")
+        message(FATAL_ERROR "No CUDA compiler found! Please ensure the CUDA Toolkit "
+            "is installed, or set JAX_FINUFFT_USE_CUDA=OFF to disable GPU support.")
         set(FINUFFT_USE_CUDA OFF)
     endif()
 else()

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ python -m pip install .
 The `CPATH` export is needed so that the build can find the headers for libraries like FFTW installed through conda.
 
 For a GPU build, while the CUDA libraries and compiler are nominally available through conda,
-our experience trying to install them through conda suggests that the "traditional"
+our experience trying to install them this way suggests that the "traditional"
 way of obtaining the [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) directly
 from NVIDIA may work best (see [related advice for Horovod](https://horovod.readthedocs.io/en/stable/conda_include.html)). After installing the CUDA Toolkit, one can set up the rest of the dependencies with:
 
@@ -65,7 +65,9 @@ python -m pip install "jax[cuda11_local]" -f https://storage.googleapis.com/jax-
 python -m pip install .
 ```
 
-In the `CMAKE_ARGS` line, you'll need to select the CUDA architecture(s) you wish to compile for. To query your GPU's CUDA architecture (compute capability), you can run:
+Other ways of installing JAX are given on the JAX website; the ["local CUDA" install methods](https://jax.readthedocs.io/en/latest/installation.html#pip-installation-gpu-cuda-installed-locally-harder) are preferred for jax-finufft as this ensures the CUDA extensions are compiled with the same Toolkit version as the CUDA runtime.
+
+In the above `CMAKE_ARGS` line, you'll need to select the CUDA architecture(s) you wish to compile for. To query your GPU's CUDA architecture (compute capability), you can run:
 
 ```bash
 $ nvidia-smi --query-gpu=compute_cap --format=csv,noheader

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ _For now, only a source build is supported._
 For building, you should only need a recent version of Python (>3.6) and
 [FFTW](https://www.fftw.org/). GPU-enabled builds also require a working CUDA
 compiler (i.e. the CUDA Toolkit), CUDA >= 11.8, and a compatible cuDNN (older versions of CUDA may work but
-are untested). At runtime, you'll need `numpy`, `scipy`, and `jax`.
+are untested). At runtime, you'll need `numpy` and `jax`.
 
 First, clone the repo and `cd` into the repo root (don't forget the `--recursive` flag because FINUFFT is included as a submodule):
 ```bash
@@ -65,7 +65,20 @@ python -m pip install "jax[cuda11_local]" -f https://storage.googleapis.com/jax-
 python -m pip install .
 ```
 
-In the `CMAKE_ARGS` line, you'll need to select the CUDA architecture(s) you wish to compile for. See the [FINUFFT docs](https://finufft.readthedocs.io/en/latest/install_gpu.html#cmake-installation).
+In the `CMAKE_ARGS` line, you'll need to select the CUDA architecture(s) you wish to compile for. To query your GPU's CUDA architecture (compute capability), you can run:
+
+```bash
+$ nvidia-smi --query-gpu=compute_cap --format=csv,noheader
+7.0
+```
+
+This corresponds to `CMAKE_CUDA_ARCHITECTURES=70`, i.e.:
+
+```bash
+export CMAKE_ARGS="-DCMAKE_CUDA_ARCHITECTURES=70 -DJAX_FINUFFT_USE_CUDA=ON"
+```
+
+Note that the pip installation is running CMake, so `CMAKE_ARGS` has to be set before then, but is not needed at runtime.
 
 At runtime, you may also need:
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "Dan Foreman-Mackey", email = "foreman.mackey@gmail.com" }]
 requires-python = ">=3.8"
 license = { file = "LICENSE" }
 urls = { Homepage = "https://github.com/dfm/jax-finufft" }
-dependencies = ["jax", "jaxlib"]
+dependencies = ["jax", "numpy"]
 dynamic = ["version"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Removing a confusing link in the documentation per #64. Also cleaning up some unnecessary(?) references to scipy and jaxlib, adding a missing numpy dep, and adding more info on JAX installation.