### PR TITLE
Fix 1D GPU warning, and a few build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,21 @@ if(JAX_FINUFFT_USE_CUDA)
 
     if(CMAKE_CUDA_COMPILER)
         message(STATUS "jax_finufft: CUDA compiler found; compiling with GPU support")
-        enable_language(CUDA)
+
         set(FINUFFT_USE_CUDA ON)
+
+        if(NOT CMAKE_CUDA_ARCHITECTURES)
+            set(CMAKE_CUDA_ARCHITECTURES "native")
+        endif()
+
+        message(STATUS "jax_finufft: CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
+
+        # Propagate to finufft, because it doesn't look at CMAKE_CUDA_ARCHITECTURES by default
+        set(FINUFFT_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
+
+        # This needs to be run after the CMAKE_CUDA_ARCHITECTURES check, otherwise
+        # it will set it to the compiler default
+        enable_language(CUDA)
     else()
         message(FATAL_ERROR "jax_finufft: No CUDA compiler found! Please ensure the "
             "CUDA Toolkit is installed, or set JAX_FINUFFT_USE_CUDA=OFF to disable "

--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ through the [cuFINUFFT interface](https://finufft.readthedocs.io/en/latest/c_gpu
 of the FINUFFT library.
 
 [Type 1 and 2](https://finufft.readthedocs.io/en/latest/math.html) transforms
-are supported in 1-, 2-, and 3-dimensions. All of these functions support
-forward, reverse, and higher-order differentiation, as well as batching using
-`vmap`.
+are supported in 1, 2, and 3 dimensions on the CPU, and 2 and 3 dimensions on the GPU.
+All of these functions support forward, reverse, and higher-order differentiation,
+as well as batching using `vmap`.
+
+> [!NOTE]
+> The GPU backend does not currently support 1D (#125).
 
 ## Installation
 
@@ -202,7 +205,8 @@ transforms). If you're already familiar with the [Python
 interface](https://finufft.readthedocs.io/en/latest/python.html) to FINUFFT,
 _please note that the function signatures here are different_!
 
-For example, here's how you can do a 1-dimensional type 1 transform:
+For example, here's how you can do a 1-dimensional type 1 transform
+(only works on CPU):
 
 ```python
 import numpy as np
@@ -227,7 +231,7 @@ Noting that the `eps` and `iflag` are optional, and that (for good reason, I
 promise!) the order of the positional arguments is reversed from the `finufft`
 Python package.
 
-The syntax for a 2-, or 3-dimensional transform is:
+The syntax for a 2-, or 3-dimensional transform (CPU or GPU) is:
 
 ```python
 f = nufft1((Nx, Ny), c, x, y)  # 2D
@@ -245,6 +249,10 @@ c = nufft2(f, x, y, z)  # 3D
 
 All of these functions support batching using `vmap`, and forward and reverse
 mode differentiation.
+
+## Selecting a platform
+If you compiled jax-finufft with GPU support, you can force it to use a particular
+backend by setting the environment variable `JAX_PLATFORMS=cpu` or `JAX_PLATFORMS=cuda`.
 
 ## Advanced usage
 
@@ -308,7 +316,7 @@ are currently only listed in source code form in
 This package, developed by Dan Foreman-Mackey is licensed under the Apache
 License, Version 2.0, with the following copyright:
 
-Copyright 2021, 2022, 2023 The Simons Foundation, Inc.
+Copyright 2021-2024 The Simons Foundation, Inc.
 
 If you use this software, please cite the primary references listed on the
 [FINUFFT docs](https://finufft.readthedocs.io/en/latest/refs.html).

--- a/README.md
+++ b/README.md
@@ -247,13 +247,6 @@ c = np.random.standard_normal(size=M) + 1j * np.random.standard_normal(size=M)
 f = nufft1(N, c, x, eps=1e-6, iflag=1)
 ```
 
-> [!WARNING]
-> As described in [the FINUFFT
-> documentation](https://finufft.readthedocs.io/en/latest/math.html), the
-> non-uniform points must lie within the range `[-3pi, 3pi]`, but this is _not
-> checked_, because JAX currently doesn't have a good interface for runtime
-> value checking. Unexpected crashes may occur if this condition is not met.
-
 Noting that the `eps` and `iflag` are optional, and that (for good reason, I
 promise!) the order of the positional arguments is reversed from the `finufft`
 Python package.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ All of these functions support forward, reverse, and higher-order differentiatio
 as well as batching using `vmap`.
 
 > [!NOTE]
-> The GPU backend does not currently support 1D (#125).
+> The GPU backend does not currently support 1D ([#125](https://github.com/flatironinstitute/jax-finufft/issues/125)).
 
 ## Installation
 
@@ -139,7 +139,7 @@ There are several important CMake variables that control aspects of the jax-finu
 
 - **`JAX_FINUFFT_USE_CUDA`** [disabled by default]: build with GPU support
 - **`CMAKE_CUDA_ARCHITECTURES`** [default `native`]: the target GPU architecture. `native` means the GPU arch of the build system.
-- **`FINUFFT_ARCH_FLAGS`** [default `-march=native`]: the target CPU architecture. `native` means the CPU arch of the build system.
+- **`FINUFFT_ARCH_FLAGS`** [default `-march=native`]: the target CPU architecture. The default is the native CPU arch of the build system.
 
 Each of these can be set as `-Ccmake.define.NAME=VALUE` arguments to `pip install`. For example,
 to build with GPU support from the repo root, run:

--- a/src/jax_finufft/lowering.py
+++ b/src/jax_finufft/lowering.py
@@ -43,7 +43,7 @@ def lowering(
 
     ndim = len(points)
     assert 1 <= ndim <= 3
-    if platform == "gpu" and ndim == 1:
+    if platform == "cuda" and ndim == 1:
         raise ValueError("1-D transforms are not yet supported on the GPU")
 
     source_aval = ctx.avals_in[0]


### PR DESCRIPTION
I was confused why a user's build wasn't working, until I realized that the test code was 1D, which isn't implemented on the GPU. We were getting a low-level error message instead of our friendly error, because the check to emit the friendly error was `if platform == "gpu"` instead of `if platform == "cuda"`.  This PR fixes that.

While trying to diagnose this, I noticed a few other places to improve the build:
- `FINUFFT_CUDA_ARCHITECTURES` was using `native` no matter the value of `CMAKE_CUDA_ARCHITECTURES`, so now we propagate that value;
- `FINUFFT_ARCH_FLAGS` is `-march=native` by default, so now we document that;
- `CMAKE_CUDA_ARCHITECTURES` usually defaults to an old value that works but triggers PTX JIT at runtime, so now we set it to `native` (and document that).

I also revamped the instructions for passing CMake args to the build.