### PR TITLE
ci: bump nvidia container image

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -3,5 +3,6 @@ FROM nvidia/cuda:12.6.3-cudnn-devel-ubuntu24.04
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-full \
+    python3-dev \
     git \
     libfftw3-dev

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04
+FROM nvidia/cuda:12.6.3-cudnn-devel-ubuntu24.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -2,7 +2,6 @@ FROM nvidia/cuda:12.6.3-cudnn-devel-ubuntu24.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    python3 \
-    python3-pip \
+    python3-full \
     git \
     libfftw3-dev

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
             }
             steps {
                 sh 'python3 -m pip install -U pip'
-                sh 'python3 -m pip install -U "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html'
+                sh 'python3 -m pip install -U "jax[cuda12]"'
                 sh 'python3 -m pip install -v .[test]'
             }
         }

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -18,27 +18,37 @@ pipeline {
                 CMAKE_ARGS = "-DJAX_FINUFFT_USE_CUDA=ON"
             }
             steps {
-                sh 'python3 -m pip install -U pip'
-                sh 'python3 -m pip install -U "jax[cuda12]"'
-                sh 'python3 -m pip install -v .[test]'
+                sh '''
+                    python3 -m venv venv
+                    . venv/bin/activate
+                    pip install -U pip
+                    pip install -U "jax[cuda12]"
+                    pip install -v ".[test]"
+                '''
             }
         }
         stage('CPU Tests') {
             environment {
                 JAX_PLATFORMS = "cpu"
-                OMP_NUM_THREADS = "4"
+                OMP_NUM_THREADS = "${env.PARALLEL}"
             }
             steps {
-                sh 'python3 -m pytest -v tests/'
+                sh '''
+                    . venv/bin/activate
+                    pytest -v tests/
+                '''
             }
         }
         stage('GPU Tests') {
             environment {
                 JAX_PLATFORMS = "cuda"
-                OMP_NUM_THREADS = "4"
+                OMP_NUM_THREADS = "${env.PARALLEL}"
             }
             steps {
-                sh 'python3 -m pytest -v tests/'
+                sh '''
+                    . venv/bin/activate
+                    pytest -v tests/
+                '''
             }
         }
     }


### PR DESCRIPTION
Jenkins is failing currently with

```
FAILED tests/shapes_test.py::test_unpadded_points - jaxlib.xla_extension.XlaRuntimeError: INTERNAL: ptxas exited with non-zero error code 65280, output: ptxas /tmp/tempfile-2f091a03f557-7b9fa04b6985ad76-5197-629dfbee58de0, line 5; fatal   : Unsupported .version 8.3; current version is '8.2'
```

Most likely this is a version compatibility issue between JAX (or some PyPI CUDA dependency) and the driver or local CTK in the image. I think a Docker image version bump may fix it.

In the future, we might want to consider a multi-stage process where we compile jax-finufft in the CUDA `devel` image and then test in a plain image using PyPI CUDA, but I don't think we're quite to the point of needing that yet.