### PR TITLE
finufft: update to 2.4

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+../ci/Dockerfile

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "CUDA",
+  "runArgs": [
+    "--gpus=all"
+  ],
+  "build": {
+    "dockerfile": "Dockerfile"
+  }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,6 @@ if(JAX_FINUFFT_USE_CUDA)
 
         message(STATUS "jax_finufft: CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 
-        # Propagate to finufft, because it doesn't look at CMAKE_CUDA_ARCHITECTURES by default
-        set(FINUFFT_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
-
         # This needs to be run after the CMAKE_CUDA_ARCHITECTURES check, otherwise
         # it will set it to the compiler default
         enable_language(CUDA)

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.6.3-cudnn-devel-ubuntu24.04
+FROM nvidia/cuda:12.9.0-cudnn-devel-ubuntu24.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -8,4 +8,4 @@ RUN apt-get update && \
     curl \
     libfftw3-dev
 
-COPY --from=ghcr.io/astral-sh/uv:0.6.17 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.7.11 /uv /uvx /bin/

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
             }
             steps {
                 sh '''
-                    uv run --extra test pytest -n 8 tests/
+                    uv run --extra test pytest -n 8
                 '''
             }
         }
@@ -34,7 +34,7 @@ pipeline {
             steps {
                 // TODO: add "-n 8", but GPU kernels don't seem to be thread-safe
                 sh '''
-                    uv run --extra test --extra cuda12 pytest tests/
+                    uv run --extra test --extra cuda12 pytest
                 '''
             }
         }

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
             steps {
                 // TODO: add "-n 8", but GPU kernels don't seem to be thread-safe
                 sh '''
-                    uv run --extra test --extra cuda12 pytest
+                    uv run --extra test --extra cuda12-local pytest
                 '''
             }
         }

--- a/lib/jax_finufft_cpu.cc
+++ b/lib/jax_finufft_cpu.cc
@@ -115,14 +115,13 @@ NB_MODULE(jax_finufft_cpu, m) {
 
   nb::class_<finufft_opts> opts(m, "FinufftOpts");
   opts.def("__init__",
-           [](finufft_opts *self, bool modeord, bool chkbnds, int debug, int spread_debug,
+           [](finufft_opts *self, bool modeord, int debug, int spread_debug,
               bool showwarn, int nthreads, int fftw, int spread_sort, bool spread_kerevalmeth,
               bool spread_kerpad, double upsampfac, int spread_thread, int maxbatchsize,
               int spread_nthr_atomic, int spread_max_sp_size) {
              new (self) finufft_opts;
              default_opts<double>(self);
              self->modeord = int(modeord);
-             self->chkbnds = int(chkbnds);
              self->debug = debug;
              self->spread_debug = spread_debug;
              self->showwarn = int(showwarn);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = ["pytest", "pytest-xdist", "absl-py"]
 cuda12 = ["jax[cuda12]"]
+cuda12-local = ["jax[cuda12-local]"]
 
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"

--- a/src/jax_finufft/options.py
+++ b/src/jax_finufft/options.py
@@ -44,7 +44,6 @@ class Opts:
     # These correspond to the default cufinufft options
     # set in vendor/finufft/src/cuda/cufinufft.cu
     modeord: bool = False
-    chkbnds: bool = True
     debug: DebugLevel = DebugLevel.Silent
     spread_debug: DebugLevel = DebugLevel.Silent
     showwarn: bool = False
@@ -77,7 +76,6 @@ class Opts:
         compiled_with_omp = jax_finufft_cpu._omp_compile_check()
         return jax_finufft_cpu.FinufftOpts(
             self.modeord,
-            self.chkbnds,
             int(self.debug),
             int(self.spread_debug),
             self.showwarn,


### PR DESCRIPTION
Update our vendored finufft dependency to 2.4, and remove some references to deprecated functionality (`FINUFFT_CUDA_ARCHITECTURES`, `chkbnds`).

Technically the `chkbnds` removal breaks the API, so perhaps now is the time for v1.0? Or we could keep `chkbnds`, it's a no-op (finufft removed it, though).

Building and testing this was actually quite hard (even with old finufft). I was running into all sorts of low-level runtime errors unless the CUDA/cuDNN versions were in a very narrow range. According to the JAX docs, I think it's supposed to work with a much broader range. I ended up using a dev container so I could match the versions better, which wasn't such a bad solution. I've added that config to the repo; some users may find it useful, too, especially until we start building CUDA wheels.