### PR TITLE
fix wheel/sdist build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build sdist
         run: uv build --sdist
       - name: Check the sdist
-        run: python -m twine check dist/*.tar.gz
+        run: uvx twine check dist/*.tar.gz
       - uses: actions/upload-artifact@v4
         with:
           name: sdist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "*"
+  pull_request:
 
 jobs:
   build_wheels:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,6 @@ config-settings = {"cmake.define.FINUFFT_ARCH_FLAGS" = ""}
 [tool.cibuildwheel.linux]
 before-all = "yum install -y fftw-devel"
 
-[tool.cibuildwheel.macos]
-before-all = "brew install fftw"
-
 # Needed for full C++17 support
 [tool.cibuildwheel.macos.environment]
 MACOSX_DEPLOYMENT_TARGET = "10.14"


### PR DESCRIPTION
The release pipeline is all kinds of broken! Both sdist and wheel builds are failing.

The sdist fix should be a quick one. The wheel build is failing on MacOS with a delocation error:

```
  delocate.libsana.DelocationError: Library dependencies do not satisfy target MacOS version 11.0:
  /private/var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/tmpnfrjuj62/wheel/jax_finufft/.dylibs/libfftw3f.3.dylib has a minimum target of 14.0
  /private/var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/tmpnfrjuj62/wheel/jax_finufft/.dylibs/libfftw3.3.dylib has a minimum target of 14.0
  Set the environment variable 'MACOSX_DEPLOYMENT_TARGET=14.0' to update minimum supported macOS for this wheel.
```

I think this is because we're brew-installing fftw, which is installing it for the current runner (macos-14) rather than the target platform (11.0). cibuildwheel mentions this pitfall: https://cibuildwheel.pypa.io/en/stable/faq/#macos-library-dependencies-do-not-satisfy-target-macos

finufft is now smart enough to fetch and build its own fftw through CPM, so if we're lucky, simply removing the brew install will be enough to fix this.