### PR TITLE
add freethreaded support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: 3.13
-      include:
-        - os: ubuntu-latest
-          python-version: 3.13t
+        include:
+          - os: ubuntu-latest
+            python-version: 3.13t
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        python-version: 3.13
+      include:
+        - os: ubuntu-latest
+          python-version: 3.13t
 
     steps:
       - uses: actions/checkout@v4
@@ -41,4 +45,10 @@ jobs:
         run: brew install fftw
 
       - name: Run tests
-        run: uv run --extra test --python 3.12 pytest -n auto tests
+        run: uv run --extra test --python ${{ matrix.python-version }} pytest -n auto tests
+
+      - name: Run freethreaded tests
+        if: endsWith(matrix.python-version, 't')
+        env:
+          JAX_FINUFFT_FORCE_FREETHREADED_TEST: 1
+        run: uv run --extra test --python ${{ matrix.python-version }} pytest -n auto tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,9 +46,3 @@ jobs:
 
       - name: Run tests
         run: uv run --extra test --python ${{ matrix.python-version }} pytest -n auto tests
-
-      - name: Run freethreaded tests
-        if: endsWith(matrix.python-version, 't')
-        env:
-          JAX_FINUFFT_FORCE_FREETHREADED_TEST: 1
-        run: uv run --extra test --python ${{ matrix.python-version }} pytest -n auto tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: 3.13
+        python-version: [3.13]
         include:
           - os: ubuntu-latest
             python-version: 3.13t

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   tests:
-    name: ${{ matrix.os }}
+    name: ${{ matrix.os }}-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # Build the CPU XLA bindings
-nanobind_add_module(jax_finufft_cpu ${CMAKE_CURRENT_LIST_DIR}/lib/jax_finufft_cpu.cc)
+nanobind_add_module(jax_finufft_cpu FREE_THREADED ${CMAKE_CURRENT_LIST_DIR}/lib/jax_finufft_cpu.cc)
 target_link_libraries(jax_finufft_cpu PRIVATE finufft)
 
 if (NOT FFTW_INCLUDE_DIRS)
@@ -109,6 +109,7 @@ if(FINUFFT_USE_CUDA)
         ${CMAKE_CURRENT_LIST_DIR}/vendor/finufft/include/cufinufft/contrib/cuda_samples
     )
     nanobind_add_module(jax_finufft_gpu
+        FREE_THREADED
         ${CMAKE_CURRENT_LIST_DIR}/lib/jax_finufft_gpu.cc
         ${CMAKE_CURRENT_LIST_DIR}/lib/cufinufft_wrapper.cc
         ${CMAKE_CURRENT_LIST_DIR}/lib/kernels.cc.cu)

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -43,10 +43,8 @@ pipeline {
                 JAX_PLATFORMS = "cuda"
                 OMP_NUM_THREADS = "${env.PARALLEL}"
                 CMAKE_ARGS = "-DJAX_FINUFFT_USE_CUDA=ON"
-                JAX_FINUFFT_FORCE_FREETHREADED_TEST= "1"
             }
             steps {
-                // TODO: add "-n 8", but GPU kernels don't seem to be thread-safe
                 sh '''
                     uv run -p 3.13t --extra test --extra cuda12-local pytest
                 '''

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -38,5 +38,19 @@ pipeline {
                 '''
             }
         }
+        stage('Free-threaded GPU Tests') {
+            environment {
+                JAX_PLATFORMS = "cuda"
+                OMP_NUM_THREADS = "${env.PARALLEL}"
+                CMAKE_ARGS = "-DJAX_FINUFFT_USE_CUDA=ON"
+                JAX_FINUFFT_FORCE_FREETHREADED_TEST= "1"
+            }
+            steps {
+                // TODO: add "-n 8", but GPU kernels don't seem to be thread-safe
+                sh '''
+                    uv run -p 3.13t --extra test --extra cuda12-local pytest
+                '''
+            }
+        }
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ version_file = "src/jax_finufft/jax_finufft_version.py"
 skip = "pp* *-musllinux_* *-manylinux_i686 cp31?t-*"
 build-verbosity = 1
 config-settings = { "cmake.define.FINUFFT_ARCH_FLAGS" = "" }
+enable = "cpython-freethreading"
 test-command = "pytest {project}/tests"
 test-extras = "test"
 # jaxlib does not support Python 3.14 yet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["nanobind", "scikit-build-core>=0.5"]
+requires = ["nanobind @ git+https://github.com/lgarrison/nanobind.git@314t-symbol", "scikit-build-core>=0.5"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["nanobind @ git+https://github.com/lgarrison/nanobind.git@314t-symbol", "scikit-build-core>=0.5"]
+requires = ["nanobind", "scikit-build-core>=0.5"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -37,7 +37,8 @@ build-dir = "build/{wheel_tag}"
 version_file = "src/jax_finufft/jax_finufft_version.py"
 
 [tool.cibuildwheel]
-skip = "pp* *-musllinux_* *-manylinux_i686"
+# For macos-314t, waiting for https://github.com/wjakob/nanobind/pull/1128 to be released
+skip = "pp* *-musllinux_* *-manylinux_i686 cp314t-macosx*"
 build-verbosity = 1
 config-settings = { "cmake.define.FINUFFT_ARCH_FLAGS" = "" }
 enable = "cpython-freethreading"
@@ -45,7 +46,7 @@ test-command = "pytest {project}/tests"
 test-extras = "test"
 # jaxlib does not support Python 3.14 yet
 # jaxlib does not support free-threading on macOS yet
-test-skip = "cp314* cp313t-macosx*"
+test-skip = "cp314* cp31?t-macosx*"
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y fftw-devel"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ enable = "cpython-freethreading"
 test-command = "pytest {project}/tests"
 test-extras = "test"
 # jaxlib does not support Python 3.14 yet
-test-skip = "cp314*"
+# jaxlib does not support free-threading on macOS yet
+test-skip = "cp314* cp313t-macosx*"
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y fftw-devel"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ build-dir = "build/{wheel_tag}"
 version_file = "src/jax_finufft/jax_finufft_version.py"
 
 [tool.cibuildwheel]
-skip = "pp* *-musllinux_* *-manylinux_i686 cp31?t-*"
+skip = "pp* *-musllinux_* *-manylinux_i686"
 build-verbosity = 1
 config-settings = { "cmake.define.FINUFFT_ARCH_FLAGS" = "" }
 enable = "cpython-freethreading"

--- a/tests/freethreaded_test.py
+++ b/tests/freethreaded_test.py
@@ -1,0 +1,62 @@
+import concurrent.futures
+import os
+import sys
+
+import numpy as np
+import pytest
+import jax
+
+import jax_finufft
+
+JAX_FINUFFT_FORCE_FREETHREADED_TEST = (
+    os.environ.get('JAX_FINUFFT_FORCE_FREETHREADED_TEST', '0') == '1'
+)
+
+
+def nogil_or_exit():
+    try:
+        gil_enabled = sys._is_gil_enabled()
+    except AttributeError:
+        gil_enabled = True
+
+    if gil_enabled:
+        if JAX_FINUFFT_FORCE_FREETHREADED_TEST:
+            pytest.fail(
+                'JAX_FINUFFT_FORCE_FREETHREADED_TEST is set, but Python is not running in free-threaded mode.'
+            )
+        else:
+            pytest.skip('Python is not running in free-threaded mode')
+
+
+def test_threaded_pool_nufft1(N_transforms=1000, N_points=1000):
+    """
+    Test concurrent computation of nufft1 transforms using ThreadPoolExecutor.
+    """
+    nogil_or_exit()
+
+    rng = np.random.default_rng(42)
+    modes = 64
+
+    x_values = rng.uniform(-np.pi, np.pi, size=(N_transforms, N_points))
+    c_values = rng.normal(size=(N_transforms, N_points)) + 1j * rng.normal(size=(N_transforms, N_points))
+    
+    def compute_transform(idx):
+        """Compute a single nufft1 transform."""
+        return np.array(jax_finufft.nufft1(
+            modes, c_values[idx], x_values[idx], eps=1e-6
+        ))
+    
+    # Sequential computation
+    sequential_results = [compute_transform(i) for i in range(N_transforms)]
+    
+    # Parallel computation using ThreadPoolExecutor
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = [executor.submit(compute_transform, i) for i in range(N_transforms)]
+        parallel_results = [future.result() for future in futures]
+    
+    # Verify results are the same
+    assert len(sequential_results) == N_transforms
+    assert len(parallel_results) == N_transforms
+    
+    for seq_res, par_res in zip(sequential_results, parallel_results):
+        np.testing.assert_allclose(seq_res, par_res, rtol=1e-4)

--- a/tests/freethreaded_test.py
+++ b/tests/freethreaded_test.py
@@ -1,9 +1,7 @@
 import concurrent.futures
-import os
 import sys
 import sysconfig
 
-import jax
 import numpy as np
 import pytest
 

--- a/tests/freethreaded_test.py
+++ b/tests/freethreaded_test.py
@@ -4,6 +4,7 @@ import sysconfig
 
 import numpy as np
 import pytest
+from ops_test import check_close
 
 import jax_finufft
 
@@ -32,6 +33,8 @@ def test_threaded_pool_nufft1(N_transforms=1000, N_points=1000):
 
     rng = np.random.default_rng(42)
     modes = 64
+    x64 = False
+    eps = 1e-10 if x64 else 1e-7
 
     x_values = rng.uniform(-np.pi, np.pi, size=(N_transforms, N_points))
     c_values = rng.normal(size=(N_transforms, N_points)) + 1j * rng.normal(
@@ -41,7 +44,7 @@ def test_threaded_pool_nufft1(N_transforms=1000, N_points=1000):
     def compute_transform(idx):
         """Compute a single nufft1 transform."""
         return np.array(
-            jax_finufft.nufft1(modes, c_values[idx], x_values[idx], eps=1e-6)
+            jax_finufft.nufft1(modes, c_values[idx], x_values[idx], eps=eps)
         )
 
     # Sequential computation
@@ -57,4 +60,4 @@ def test_threaded_pool_nufft1(N_transforms=1000, N_points=1000):
     assert len(parallel_results) == N_transforms
 
     for seq_res, par_res in zip(sequential_results, parallel_results):
-        np.testing.assert_allclose(seq_res, par_res, rtol=1e-4)
+        check_close(seq_res, par_res, rtol=1e-3)

--- a/tests/freethreaded_test.py
+++ b/tests/freethreaded_test.py
@@ -1,31 +1,29 @@
 import concurrent.futures
 import os
 import sys
+import sysconfig
 
+import jax
 import numpy as np
 import pytest
-import jax
 
 import jax_finufft
 
-JAX_FINUFFT_FORCE_FREETHREADED_TEST = (
-    os.environ.get('JAX_FINUFFT_FORCE_FREETHREADED_TEST', '0') == '1'
-)
-
 
 def nogil_or_exit():
+    freethreaded_build = sysconfig.get_config_var("Py_GIL_DISABLED")
     try:
         gil_enabled = sys._is_gil_enabled()
     except AttributeError:
         gil_enabled = True
 
-    if gil_enabled:
-        if JAX_FINUFFT_FORCE_FREETHREADED_TEST:
+    if freethreaded_build:
+        if gil_enabled:
             pytest.fail(
-                'JAX_FINUFFT_FORCE_FREETHREADED_TEST is set, but Python is not running in free-threaded mode.'
+                "Python was built with free-threading but is not running in free-threaded mode."
             )
-        else:
-            pytest.skip('Python is not running in free-threaded mode')
+    else:
+        pytest.skip("Python not built in free-threaded mode")
 
 
 def test_threaded_pool_nufft1(N_transforms=1000, N_points=1000):
@@ -38,25 +36,27 @@ def test_threaded_pool_nufft1(N_transforms=1000, N_points=1000):
     modes = 64
 
     x_values = rng.uniform(-np.pi, np.pi, size=(N_transforms, N_points))
-    c_values = rng.normal(size=(N_transforms, N_points)) + 1j * rng.normal(size=(N_transforms, N_points))
-    
+    c_values = rng.normal(size=(N_transforms, N_points)) + 1j * rng.normal(
+        size=(N_transforms, N_points)
+    )
+
     def compute_transform(idx):
         """Compute a single nufft1 transform."""
-        return np.array(jax_finufft.nufft1(
-            modes, c_values[idx], x_values[idx], eps=1e-6
-        ))
-    
+        return np.array(
+            jax_finufft.nufft1(modes, c_values[idx], x_values[idx], eps=1e-6)
+        )
+
     # Sequential computation
     sequential_results = [compute_transform(i) for i in range(N_transforms)]
-    
+
     # Parallel computation using ThreadPoolExecutor
     with concurrent.futures.ThreadPoolExecutor() as executor:
         futures = [executor.submit(compute_transform, i) for i in range(N_transforms)]
         parallel_results = [future.result() for future in futures]
-    
+
     # Verify results are the same
     assert len(sequential_results) == N_transforms
     assert len(parallel_results) == N_transforms
-    
+
     for seq_res, par_res in zip(sequential_results, parallel_results):
         np.testing.assert_allclose(seq_res, par_res, rtol=1e-4)


### PR DESCRIPTION
Build the nanobind extensions as free-threaded compatible, and run a test with multiple Python threads. The main purpose of the test is to check that we didn't fall out of nogil mode, and that nothing crashes, rather than measure performance.

Builds off #149.