### PR TITLE
lib: fix sharded inputs

### DIFF
--- a/lib/cufinufft_wrapper.cc
+++ b/lib/cufinufft_wrapper.cc
@@ -36,6 +36,16 @@ void update_opts<double>(cufinufft_opts* opts, int dim, cudaStream_t stream) {
 }
 
 template <>
+void update_opts<float>(cufinufft_opts* opts, int dim, device_type device) {
+  opts->gpu_device_id = device.ordinal;
+}
+
+template <>
+void update_opts<double>(cufinufft_opts* opts, int dim, device_type device) {
+  opts->gpu_device_id = device.ordinal;
+}
+
+template <>
 int makeplan<float>(int type, int dim, const int64_t nmodes[3], int iflag, int ntr, float eps,
                     typename plan_type<float>::type* plan, cufinufft_opts* opts) {
   int64_t tmp_nmodes[3] = {nmodes[0], nmodes[1],

--- a/lib/cufinufft_wrapper.h
+++ b/lib/cufinufft_wrapper.h
@@ -22,11 +22,18 @@ struct plan_type<float> {
   typedef cufinufftf_plan type;
 };
 
+struct device_type {
+  int ordinal;
+};
+
 template <typename T>
 void default_opts(cufinufft_opts* opts);
 
 template <typename T>
 void update_opts(cufinufft_opts* opts, int dim, cudaStream_t stream);
+
+template <typename T>
+void update_opts(cufinufft_opts* opts, int dim, device_type device);
 
 template <typename T>
 int makeplan(int type, int dim, const int64_t nmodes[3], int iflag, int ntr, T eps,

--- a/lib/kernels.cc.cu
+++ b/lib/kernels.cc.cu
@@ -20,6 +20,9 @@ void run_nufft(int type, const descriptor<T>* descriptor, T* x, T* y, T* z, std:
 
   cufinufft_opts opts = descriptor->opts;
   update_opts<T>(&opts, ndim, stream);
+  device_type device;
+  ThrowIfError(cudaGetDevice(&device.ordinal));
+  update_opts<T>(&opts, ndim, device);
 
   typename plan_type<T>::type plan;
   makeplan<T>(type, ndim, descriptor->n_k, descriptor->iflag, descriptor->n_transf,


### PR DESCRIPTION
cufinufft library uses `opts.gpu_device_id` to determine the device ordinal to execute on. In the patch the correct device id is determined and provided to the plan.