### PR TITLE
dependencies: jax<0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 urls = { Homepage = "https://github.com/dfm/jax-finufft" }
-dependencies = ["jax>=0.5.0", "numpy", "pydantic>=2"]
+dependencies = ["jax>=0.5.0,<0.8", "numpy", "pydantic>=2"]
 dynamic = ["version"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Temporary upper bound pin while we port `mlir.custom_call` to `jax.ffi`.