### PR TITLE
options: add gpu_debug

### DIFF
--- a/lib/jax_finufft_gpu.cc
+++ b/lib/jax_finufft_gpu.cc
@@ -56,7 +56,7 @@ NB_MODULE(jax_finufft_gpu, m) {
            [](cufinufft_opts* self, bool modeord, double upsampfac, int gpu_method, bool gpu_sort,
               int gpu_binsizex, int gpu_binsizey, int gpu_binsizez, int gpu_obinsizex,
               int gpu_obinsizey, int gpu_obinsizez, int gpu_maxsubprobsize, bool gpu_kerevalmeth,
-              int gpu_spreadinterponly, int gpu_maxbatchsize) {
+              int gpu_spreadinterponly, int gpu_maxbatchsize, int debug) {
              new (self) cufinufft_opts;
              default_opts<double>(self);
 
@@ -74,6 +74,7 @@ NB_MODULE(jax_finufft_gpu, m) {
              self->gpu_kerevalmeth = gpu_kerevalmeth;
              self->gpu_spreadinterponly = gpu_spreadinterponly;
              self->gpu_maxbatchsize = gpu_maxbatchsize;
+             self->debug = debug;
            });
 }
 

--- a/src/jax_finufft/options.py
+++ b/src/jax_finufft/options.py
@@ -12,6 +12,11 @@ class DebugLevel(IntEnum):
     Noisy = 2
 
 
+class GpuDebugLevel(IntEnum):
+    Silent = 0
+    Verbose = 1
+
+
 class FftwFlags(IntEnum):
     Estimate = jax_finufft_cpu.FFTW_ESTIMATE
     Measure = jax_finufft_cpu.FFTW_MEASURE
@@ -71,6 +76,7 @@ class Opts:
     gpu_kerevalmeth: bool = True
     gpu_spreadinterponly: bool = False
     gpu_maxbatchsize: int = 0
+    gpu_debug: GpuDebugLevel = GpuDebugLevel.Silent
 
     def to_finufft_opts(self):
         compiled_with_omp = jax_finufft_cpu._omp_compile_check()
@@ -109,6 +115,7 @@ class Opts:
             self.gpu_kerevalmeth,
             self.gpu_spreadinterponly,
             self.gpu_maxbatchsize,
+            int(self.gpu_debug),
         )
 
 


### PR DESCRIPTION
With this, we should be exposing all GPU options. I decided not to merge this with the plain `debug` option because it seems finufft has multiple debug levels and cufinufft just has one.