### PR TITLE
wheels: remove 313t

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.13, 3.13t]
+        python-version: [3.14, 3.14t]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "ubuntu-24.04-arm", "macos-14"]
-        python: ["cp311", "cp312", "cp313", "cp313t", "cp314", "cp314t"]
+        python: ["cp311", "cp312", "cp313", "cp314", "cp314t"]
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ version_file = "src/jax_finufft/jax_finufft_version.py"
 skip = "pp* *-musllinux_* *-manylinux_i686"
 build-verbosity = 1
 config-settings = { "cmake.define.FINUFFT_ARCH_FLAGS" = "" }
-enable = "cpython-freethreading"
 test-command = "pytest {project}/tests"
 test-extras = "test"
 


### PR DESCRIPTION
Following cibuildwheel/manylinux deprecation of 313t support. Free-threaded support will primarily be 3.14+ going forward.

https://cibuildwheel.pypa.io/en/stable/changelog/#v341