### PR TITLE
ops: not_mapped removed, use None directly

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -42,7 +42,7 @@ timeout(time: 1, unit: 'HOURS') {
                         withEnv(["JAX_PLATFORMS=cuda"]) {
                             sh '''
                                 export OMP_NUM_THREADS=$PARALLEL
-                                uv run -p 3.13t --extra test --extra ${PY_CUDA_EXTRA} pytest -vs
+                                uv run -p 3.14t --extra test --extra ${PY_CUDA_EXTRA} pytest -vs
                             '''
                         }
                     }

--- a/src/jax_finufft/ops.py
+++ b/src/jax_finufft/ops.py
@@ -289,8 +289,8 @@ def batch(args, axes, *, output_shape, nufft_type, **kwargs):
 
     # If none of the points are being mapped, we can get a faster computation using
     # a single transform with num_transforms * num_repeats
-    if all(bx is batching.not_mapped for bx in bpoints):
-        assert bsource is not batching.not_mapped
+    if all(bx is None for bx in bpoints):
+        assert bsource is not None
         source = batching.moveaxis(source, bsource, 0)
         mapped_points = tuple(p[None] for p in points)
 
@@ -298,11 +298,9 @@ def batch(args, axes, *, output_shape, nufft_type, **kwargs):
         # Otherwise move the batching dimension to the front and repeat the arrays
         # to the right shape
         if bsource is None:
-            assert any(bx is not batching.not_mapped for bx in bpoints)
+            assert any(bx is not None for bx in bpoints)
             num_repeats = next(
-                x.shape[bx]
-                for x, bx in zip(points, bpoints)
-                if bx is not batching.not_mapped
+                x.shape[bx] for x, bx in zip(points, bpoints) if bx is not None
             )
             source = jnp.repeat(source[jnp.newaxis], num_repeats, axis=0)
         else:
@@ -311,7 +309,7 @@ def batch(args, axes, *, output_shape, nufft_type, **kwargs):
 
         mapped_points = []
         for x, bx in zip(points, bpoints):
-            if bx is batching.not_mapped:
+            if bx is None:
                 mapped_points.append(jnp.repeat(x[None], num_repeats, axis=0))
             else:
                 mapped_points.append(batching.moveaxis(x, bx, 0))


### PR DESCRIPTION
Following the removal of `not_mapped` in JAX v0.10.2. Upstream JAX just uses `None` directly; we'll follow suit. `not_mapped` was just an alias for `None` anyway, so should be backwards compatible.

See https://github.com/jax-ml/jax/pull/38073.

Fixes #227. cc @YigitElma.
