### PR TITLE
add manual sharding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,8 @@ processed independently, apart from the grid sum inherent in a type-1 transform.
 
 The **uniform grid** (the mode array) must be **replicated**: it is the operand of
 the FFT, which is performed locally on each device. Sharding the grid would require
-a distributed FFT, which is out of scope for now. Any **leading batch
+a distributed FFT, which is out of scope for now (but please open an issue if this
+is of interest to you). Any **leading batch
 dimensions** (stacked transforms; see [Stacked Transforms and
 Broadcasting](#stacked-transforms-and-broadcasting)) shard trivially, since those
 transforms are independent.
@@ -421,7 +422,8 @@ c = sharded_nufft2(grid, x, y)  # c.shape == (n_pts,), sharded over the points
 
 Type 3 maps nonuniform *sources* to nonuniform *targets*, and every target depends
 on every source — hence the two alternatives above, sharding one side and
-replicating the other. Sharding *both* sources and targets is currently **not supported**: this requires more complex communication patterns that are not presently implemented.
+replicating the other. Sharding *both* sources and targets is currently **not supported**: this requires more complex communication patterns that are not presently implemented (please open
+an issue if this is of interest to you).
 
 ### Gradients
 

--- a/README.md
+++ b/README.md
@@ -336,6 +336,104 @@ f = nufft1(N, c, x)
 If you compiled jax-finufft with GPU support, you can force it to use a particular
 backend by setting the environment variable `JAX_PLATFORMS=cpu` or `JAX_PLATFORMS=cuda`.
 
+## Sharding
+
+jax-finufft transforms can be distributed across multiple devices, but with
+caveats that come from how the underlying FINUFFT calls interact with JAX's
+parallelism model. The transforms are XLA custom calls (via the
+[FFI](https://docs.jax.dev/en/latest/ffi.html)), which are opaque to XLA's
+partitioner. As the [FFI sharding
+docs](https://docs.jax.dev/en/latest/ffi.html#sharding) explain, this means that
+under automatic parallelization — a plain `jax.jit` over sharded inputs —
+the inputs are **gathered onto every device** and the full transform is run
+redundantly on each (see
+[#179](https://github.com/flatironinstitute/jax-finufft/issues/179)). To actually
+distribute the work, drive the transforms with manual sharding, i.e.
+[`jax.shard_map`](https://docs.jax.dev/en/latest/sharded-computation.html); the
+rest of this section assumes that.
+
+### What can and cannot be sharded
+
+jax-finufft supports **data parallelism over the nonuniform points**. The points
+(and their strengths/coefficients) are the naturally shardable axis: each point is
+processed independently, apart from the grid sum inherent in a type-1 transform.
+
+The **uniform grid** (the mode array) must be **replicated**: it is the operand of
+the FFT, which is performed locally on each device. Sharding the grid would require
+a distributed FFT, which is out of scope for now. Any **leading batch
+dimensions** (stacked transforms; see [Stacked Transforms and
+Broadcasting](#stacked-transforms-and-broadcasting)) shard trivially, since those
+transforms are independent.
+
+### Data-parallel patterns by transform type
+
+Within a `shard_map`, each pattern below runs the transform on every device's local
+shard of the points and combines the results with at most one collective:
+
+| Transform | shard | replicate | combine |
+|---|---|---|---|
+| **Type 1** (nonuniform → uniform) | points + strengths | — | `psum` the output grid (spreading is additive over points) |
+| **Type 2** (uniform → nonuniform) | points | grid | none (each device evaluates the grid at its own points) |
+| **Type 3** (nonuniform → nonuniform) | source points + strengths | target points | `psum` the output |
+| **Type 3** (alternative) | target points | source points + strengths | none (each device evaluates all sources at its own targets) |
+
+For example, a data-parallel type 2 with the grid replicated and the points sharded
+across the mesh comes down to wrapping `nufft2` in a `shard_map`:
+
+```python
+from jax import shard_map  # jax.experimental.shard_map on JAX < 0.10
+from jax.sharding import Mesh, PartitionSpec as P
+
+mesh = Mesh(np.array(jax.devices()), ("i",))  # plain Mesh -> manual (shard_map) axes
+
+# grid replicated; points (and the output) sharded along "i"
+sharded_nufft2 = shard_map(
+    nufft2, mesh=mesh, in_specs=(P(), P("i"), P("i")), out_specs=P("i")
+)
+c = sharded_nufft2(grid, x, y)  # c.shape == (n_pts,), sharded over the points
+```
+
+<details>
+<summary>Full example</summary>
+
+```python
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import shard_map  # jax.experimental.shard_map on JAX < 0.10
+from jax.sharding import Mesh, PartitionSpec as P
+from jax_finufft import nufft2
+
+mesh = Mesh(np.array(jax.devices()), ("i",))  # plain Mesh -> manual (shard_map) axes
+n_pts = 1000 * jax.device_count()  # must be divisible by the mesh size
+
+rng = np.random.default_rng(0)
+grid = jnp.asarray(rng.standard_normal((64, 64)) + 1j * rng.standard_normal((64, 64)))
+x = jnp.asarray(rng.uniform(-np.pi, np.pi, n_pts))  # nonuniform points
+y = jnp.asarray(rng.uniform(-np.pi, np.pi, n_pts))
+
+sharded_nufft2 = shard_map(
+    nufft2, mesh=mesh, in_specs=(P(), P("i"), P("i")), out_specs=P("i")
+)
+c = sharded_nufft2(grid, x, y)  # c.shape == (n_pts,), sharded over the points
+```
+</details>
+
+Type 3 maps nonuniform *sources* to nonuniform *targets*, and every target depends
+on every source — hence the two alternatives above, sharding one side and
+replicating the other. Sharding *both* sources and targets is currently **not supported**: this requires more complex communication patterns that are not presently implemented.
+
+### Gradients
+
+These patterns differentiate correctly with plain `jax.grad` / `jax.value_and_grad`
+under `shard_map`: both the value and the gradient match the single-device result.
+Note that the cotangent of a **replicated** input — the
+grid in the type-2 pattern, or the coefficients in the type-1 pattern — must be
+summed across devices. jax-finufft inserts this sum for you,
+via JAX's varying manual axes (vma) model on **JAX >= 0.6.0**,
+and via a replication rule it registers for the older `check_rep`-based `shard_map`
+on **JAX < 0.6.0**.
+
 ## Advanced usage
 
 ### Options

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JAX bindings to FINUFFT
 
 [![GitHub Tests](https://github.com/flatironinstitute/jax-finufft/actions/workflows/tests.yml/badge.svg)](https://github.com/flatironinstitute/jax-finufft/actions/workflows/tests.yml)
-[![Jenkins Tests](https://jenkins.flatironinstitute.org/buildStatus/icon?job=jax-finufft%2Fmain&subject=Jenkins%20Tests)](https://jenkins.flatironinstitute.org/job/jax-finufft/job/main/)
+[![Jenkins Tests](https://jenkins-new.flatironinstitute.org/job/SCC/job/jax-finufft/job/main/badge/icon?subject=Jenkins+CI)](https://jenkins-new.flatironinstitute.org/job/SCC/job/jax-finufft/job/main/)
 
 This package provides a [JAX](https://github.com/google/jax) interface to the [Flatiron Institute Non-uniform Fast Fourier Transform (FINUFFT)
 library](https://github.com/flatironinstitute/finufft). Take a look at the

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -22,7 +22,7 @@ timeout(time: 1, unit: 'HOURS') {
                             '''
                     }
                     stage('CPU Tests') {
-                        withEnv(["JAX_PLATFORMS=cpu"]) {
+                        withEnv(["JAX_PLATFORMS=cpu", "JAX_FINUFFT_REQUIRE_SHARDING=1"]) {
                             sh '''
                                 export OMP_NUM_THREADS=$PARALLEL
                                 uv run --extra test pytest -n 8

--- a/src/jax_finufft/ops.py
+++ b/src/jax_finufft/ops.py
@@ -18,6 +18,34 @@ elif jax.version.__version_info__ >= (0, 4, 34):
 else:
     p2tz = ad.Zero.from_value
 
+try:
+    from jax._src.core import auto_insert_reshard as _insert_reshard  # jax >= 0.10.1
+except ImportError:
+    try:
+        from jax._src.core import (
+            standard_insert_pvary as _insert_reshard,
+        )  # 0.6.0-0.10.0
+    except ImportError:
+        _insert_reshard = (
+            None  # jax < 0.6.0: no vma tracking, may work with check_rep=False
+        )
+
+
+def reconcile_vma(source, points):
+    """Bring all inputs to a common set of varying manual axes (vma) before
+    binding.
+
+    Under ``jax.shard_map`` this inserts a ``pvary`` on any input that is
+    replicated over a manual mesh axis that the other inputs vary over. Because
+    ``pvary`` transposes to ``psum``, this supplies the cross-device gradient
+    accumulation for a replicated input -- e.g. the grid in a data-parallel
+    type-2 transform. Outside manual mode it is a no-op.
+    """
+    if _insert_reshard is None:
+        return source, points
+    source, *points = _insert_reshard(source, *points)
+    return source, points
+
 
 @partial(jit, static_argnums=(0,), static_argnames=("iflag", "eps", "opts"))
 def nufft1(output_shape, source, *points, iflag=1, eps=1e-6, opts=None):
@@ -39,6 +67,7 @@ def nufft1(output_shape, source, *points, iflag=1, eps=1e-6, opts=None):
     )
 
     # Execute the transform primitive
+    source, points = reconcile_vma(source, points)
     result = nufft1_p.bind(
         source,
         *points,
@@ -67,6 +96,7 @@ def nufft2(source, *points, iflag=-1, eps=1e-6, opts=None):
     )
 
     # Execute the transform primitive
+    source, points = reconcile_vma(source, points)
     result = nufft2_p.bind(
         source,
         *points,
@@ -110,6 +140,7 @@ def nufft3(source, *points, iflag=-1, eps=1e-6, opts=None):
     )
 
     # Execute the transform primitive
+    source, points = reconcile_vma(source, points)
     result = nufft3_p.bind(
         source,
         *points,

--- a/src/jax_finufft/ops.py
+++ b/src/jax_finufft/ops.py
@@ -27,7 +27,7 @@ except ImportError:
         )  # 0.6.0-0.10.0
     except ImportError:
         _insert_reshard = (
-            None  # jax < 0.6.0: no vma tracking, may work with check_rep=False
+            None  # jax < 0.6.0: no vma tracking, rep rule registered below
         )
 
 
@@ -384,3 +384,20 @@ if lowering.jax_finufft_gpu is not None:
 ad.primitive_jvps[nufft3_p] = partial(jvp, nufft3_p)
 ad.primitive_transposes[nufft3_p] = transpose
 batching.primitive_batchers[nufft3_p] = batch
+
+
+# Register replication rules for the pre-vma `jax.shard_map`. This is only relevant
+# on jax < 0.6.0. We reuse jax's standard rule, which inserts a `pbroadcast`
+# (transposing to `psum`) on replicated inputs.
+if jax.version.__version_info__ < (0, 6, 0):
+    try:
+        from jax.experimental.shard_map import (
+            register_standard_check,
+            register_standard_rewrite,
+        )
+
+        for _p in (nufft1_p, nufft2_p, nufft3_p):
+            register_standard_check(_p)
+            register_standard_rewrite(_p)
+    except ImportError:
+        pass

--- a/tests/sharding_test.py
+++ b/tests/sharding_test.py
@@ -29,7 +29,10 @@ except ImportError:
 
 
 def check_close(a, b, **kwargs):
-    kwargs["rtol"] = kwargs.get("rtol", {"complex128": 1e-7, "complex64": 1e-4})
+    kwargs["rtol"] = kwargs.get(
+        "rtol",
+        {"float64": 1e-7, "complex128": 1e-7, "float32": 1e-4, "complex64": 1e-4},
+    )
     return jtu.check_close(a, b, **kwargs)
 
 
@@ -41,6 +44,13 @@ else:
 
 # All tests in this module need a multi-device mesh.
 pytestmark = pytest.mark.skipif(jax.device_count() < 2, reason="requires >=2 devices")
+
+
+@pytest.fixture(autouse=True)
+def _enable_x64():
+    # Run the whole module in double precision
+    with enable_x64():
+        yield
 
 
 def _mesh():
@@ -83,30 +93,29 @@ def test_nufft2_shard_map_grad(ndim):
     def chi(g, *pts, d):
         return jnp.sum(jnp.abs(nufft2(g, *pts, eps=eps) - d) ** 2)
 
-    with enable_x64():
-        mesh = _mesh()
-        rows = NamedSharding(mesh, P("s"))
-        xs = [jax.device_put(xi, rows) for xi in x]
-        ds = jax.device_put(data, rows)
+    mesh = _mesh()
+    rows = NamedSharding(mesh, P("s"))
+    xs = [jax.device_put(xi, rows) for xi in x]
+    ds = jax.device_put(data, rows)
 
-        def local(g, *pts_and_data):
-            *pts, d = pts_and_data
-            return jax.lax.psum(chi(g, *pts, d=d), "s")
+    def local(g, *pts_and_data):
+        *pts, d = pts_and_data
+        return jax.lax.psum(chi(g, *pts, d=d), "s")
 
-        sm = shard_map(
-            local,
-            mesh=mesh,
-            in_specs=(P(),) + (P("s"),) * (ndim + 1),
-            out_specs=P(),
-        )
+    sm = shard_map(
+        local,
+        mesh=mesh,
+        in_specs=(P(),) + (P("s"),) * (ndim + 1),
+        out_specs=P(),
+    )
 
-        _check(
-            single=lambda g: chi(g, *x, d=data),
-            sharded=lambda g: sm(g, *xs, ds),
-            primal=grid,
-            primal_spec=P(),
-            mesh=mesh,
-        )
+    _check(
+        single=lambda g: chi(g, *x, d=data),
+        sharded=lambda g: sm(g, *xs, ds),
+        primal=grid,
+        primal_spec=P(),
+        mesh=mesh,
+    )
 
 
 @pytest.mark.parametrize("ndim", [1, 2, 3])
@@ -132,33 +141,32 @@ def test_nufft1_shard_map_grad(ndim):
         random.normal(size=num_uniform) + 1j * random.normal(size=num_uniform)
     )
 
-    with enable_x64():
-        mesh = _mesh()
-        rows = NamedSharding(mesh, P("s"))
-        xs = [jax.device_put(xi, rows) for xi in x]
+    mesh = _mesh()
+    rows = NamedSharding(mesh, P("s"))
+    xs = [jax.device_put(xi, rows) for xi in x]
 
-        def single(c):
-            f = nufft1(num_uniform, c, *x, eps=eps)
-            return jnp.sum(jnp.abs(f - target) ** 2)
+    def single(c):
+        f = nufft1(num_uniform, c, *x, eps=eps)
+        return jnp.sum(jnp.abs(f - target) ** 2)
 
-        def local(c, *pts):
-            f = jax.lax.psum(nufft1(num_uniform, c, *pts, eps=eps), "s")
-            return jnp.sum(jnp.abs(f - target) ** 2)
+    def local(c, *pts):
+        f = jax.lax.psum(nufft1(num_uniform, c, *pts, eps=eps), "s")
+        return jnp.sum(jnp.abs(f - target) ** 2)
 
-        sm = shard_map(
-            local,
-            mesh=mesh,
-            in_specs=(P("s"),) * (ndim + 1),
-            out_specs=P(),
-        )
+    sm = shard_map(
+        local,
+        mesh=mesh,
+        in_specs=(P("s"),) * (ndim + 1),
+        out_specs=P(),
+    )
 
-        _check(
-            single=single,
-            sharded=lambda c: sm(c, *xs),
-            primal=c,
-            primal_spec=P("s"),
-            mesh=mesh,
-        )
+    _check(
+        single=single,
+        sharded=lambda c: sm(c, *xs),
+        primal=c,
+        primal_spec=P("s"),
+        mesh=mesh,
+    )
 
 
 @pytest.mark.parametrize("ndim", [1, 2, 3])
@@ -182,36 +190,35 @@ def test_nufft3_shard_map_grad(ndim):
         random.normal(size=num_target) + 1j * random.normal(size=num_target)
     )
 
-    with enable_x64():
-        mesh = _mesh()
-        rows = NamedSharding(mesh, P("s"))
-        repl = NamedSharding(mesh, P())
-        xs = [jax.device_put(xi, rows) for xi in x]
-        ss = [jax.device_put(si, repl) for si in s]
+    mesh = _mesh()
+    rows = NamedSharding(mesh, P("s"))
+    repl = NamedSharding(mesh, P())
+    xs = [jax.device_put(xi, rows) for xi in x]
+    ss = [jax.device_put(si, repl) for si in s]
 
-        def single(c):
-            f = nufft3(c, *x, *s, eps=eps)
-            return jnp.sum(jnp.abs(f - target) ** 2)
+    def single(c):
+        f = nufft3(c, *x, *s, eps=eps)
+        return jnp.sum(jnp.abs(f - target) ** 2)
 
-        def local(c, *pts):
-            xp, sp = pts[:ndim], pts[ndim:]
-            f = jax.lax.psum(nufft3(c, *xp, *sp, eps=eps), "s")
-            return jnp.sum(jnp.abs(f - target) ** 2)
+    def local(c, *pts):
+        xp, sp = pts[:ndim], pts[ndim:]
+        f = jax.lax.psum(nufft3(c, *xp, *sp, eps=eps), "s")
+        return jnp.sum(jnp.abs(f - target) ** 2)
 
-        sm = shard_map(
-            local,
-            mesh=mesh,
-            in_specs=(P("s"),) + (P("s"),) * ndim + (P(),) * ndim,
-            out_specs=P(),
-        )
+    sm = shard_map(
+        local,
+        mesh=mesh,
+        in_specs=(P("s"),) + (P("s"),) * ndim + (P(),) * ndim,
+        out_specs=P(),
+    )
 
-        _check(
-            single=single,
-            sharded=lambda c: sm(c, *xs, *ss),
-            primal=c,
-            primal_spec=P("s"),
-            mesh=mesh,
-        )
+    _check(
+        single=single,
+        sharded=lambda c: sm(c, *xs, *ss),
+        primal=c,
+        primal_spec=P("s"),
+        mesh=mesh,
+    )
 
 
 @pytest.mark.parametrize("ndim", [1, 2, 3])
@@ -237,39 +244,38 @@ def test_nufft3_shard_map_grad_rep_source_shard_target(ndim):
         random.normal(size=num_target) + 1j * random.normal(size=num_target)
     )
 
-    with enable_x64():
-        mesh = _mesh()
-        rows = NamedSharding(mesh, P("s"))
-        repl = NamedSharding(mesh, P())
-        xs = [jax.device_put(xi, repl) for xi in x]  # sources replicated
-        ss = [jax.device_put(si, rows) for si in s]  # targets sharded
-        tgt = jax.device_put(target, rows)  # target data sharded
+    mesh = _mesh()
+    rows = NamedSharding(mesh, P("s"))
+    repl = NamedSharding(mesh, P())
+    xs = [jax.device_put(xi, repl) for xi in x]  # sources replicated
+    ss = [jax.device_put(si, rows) for si in s]  # targets sharded
+    tgt = jax.device_put(target, rows)  # target data sharded
 
-        def single(c):
-            f = nufft3(c, *x, *s, eps=eps)
-            return jnp.sum(jnp.abs(f - target) ** 2)
+    def single(c):
+        f = nufft3(c, *x, *s, eps=eps)
+        return jnp.sum(jnp.abs(f - target) ** 2)
 
-        def local(c, *pts_and_tgt):
-            xp = pts_and_tgt[:ndim]
-            sp = pts_and_tgt[ndim : 2 * ndim]
-            tg = pts_and_tgt[2 * ndim]
-            f = nufft3(c, *xp, *sp, eps=eps)  # all sources -> local targets
-            return jax.lax.psum(jnp.sum(jnp.abs(f - tg) ** 2), "s")
+    def local(c, *pts_and_tgt):
+        xp = pts_and_tgt[:ndim]
+        sp = pts_and_tgt[ndim : 2 * ndim]
+        tg = pts_and_tgt[2 * ndim]
+        f = nufft3(c, *xp, *sp, eps=eps)  # all sources -> local targets
+        return jax.lax.psum(jnp.sum(jnp.abs(f - tg) ** 2), "s")
 
-        sm = shard_map(
-            local,
-            mesh=mesh,
-            in_specs=(P(),) + (P(),) * ndim + (P("s"),) * ndim + (P("s"),),
-            out_specs=P(),
-        )
+    sm = shard_map(
+        local,
+        mesh=mesh,
+        in_specs=(P(),) + (P(),) * ndim + (P("s"),) * ndim + (P("s"),),
+        out_specs=P(),
+    )
 
-        _check(
-            single=single,
-            sharded=lambda c: sm(c, *xs, *ss, tgt),
-            primal=c,
-            primal_spec=P(),
-            mesh=mesh,
-        )
+    _check(
+        single=single,
+        sharded=lambda c: sm(c, *xs, *ss, tgt),
+        primal=c,
+        primal_spec=P(),
+        mesh=mesh,
+    )
 
 
 @pytest.mark.xfail(
@@ -296,24 +302,23 @@ def test_nufft3_shard_map_shard_source_and_target():
         random.normal(size=num_source) + 1j * random.normal(size=num_source)
     )
 
-    with enable_x64():
-        mesh = _mesh()
-        rows = NamedSharding(mesh, P("s"))
-        cs = jax.device_put(c, rows)
-        xs = [jax.device_put(xi, rows) for xi in x]
-        ss = [jax.device_put(si, rows) for si in s]
+    mesh = _mesh()
+    rows = NamedSharding(mesh, P("s"))
+    cs = jax.device_put(c, rows)
+    xs = [jax.device_put(xi, rows) for xi in x]
+    ss = [jax.device_put(si, rows) for si in s]
 
-        def local(c, *pts):
-            xp, sp = pts[:ndim], pts[ndim:]
-            return nufft3(c, *xp, *sp, eps=eps)
+    def local(c, *pts):
+        xp, sp = pts[:ndim], pts[ndim:]
+        return nufft3(c, *xp, *sp, eps=eps)
 
-        sm = shard_map(
-            local,
-            mesh=mesh,
-            in_specs=(P("s"),) + (P("s"),) * ndim + (P("s"),) * ndim,
-            out_specs=P("s"),
-        )
+    sm = shard_map(
+        local,
+        mesh=mesh,
+        in_specs=(P("s"),) + (P("s"),) * ndim + (P("s"),) * ndim,
+        out_specs=P("s"),
+    )
 
-        f_sharded = sm(cs, *xs, *ss)
-        f_ref = nufft3(c, *x, *s, eps=eps)
-        check_close(f_sharded, f_ref)  # missing cross-shard source contributions
+    f_sharded = sm(cs, *xs, *ss)
+    f_ref = nufft3(c, *x, *s, eps=eps)
+    check_close(f_sharded, f_ref)  # missing cross-shard source contributions

--- a/tests/sharding_test.py
+++ b/tests/sharding_test.py
@@ -6,7 +6,7 @@ uniform grid is replicated, and the result is reduced across devices with
 ``jax.lax.psum``. The forward transform shards trivially -- each device runs a
 local transform on its slice of points -- but the gradient of a *replicated*
 input requires a cross-device ``psum`` that is only inserted when JAX tracks
-varying manual axes (vma), i.e. jax >= 0.6.0. Without it the forward is
+varying manual axes (vma) or registers a rep rule. Without it the forward is
 correct but the gradient is silently wrong.
 """
 

--- a/tests/sharding_test.py
+++ b/tests/sharding_test.py
@@ -214,3 +214,110 @@ def test_nufft3_shard_map_grad(ndim, iflag):
             primal_spec=P("s"),
             mesh=mesh,
         )
+
+
+@pytest.mark.parametrize("ndim, iflag", product([1, 2, 3], [-1, 1]))
+def test_nufft3_shard_map_grad_rep_source_shard_target(ndim, iflag):
+    # Data-parallel type 3, complementary pattern: source coeffs + source points
+    # replicated, target points (and the loss) sharded. Each device evaluates all
+    # sources at its slice of targets, so no forward collective is needed.
+    # Differentiate w.r.t. the *replicated* coeffs -- their cotangent must be
+    # psum'd over the target shards (the pvary path), analogous to the type-2
+    # replicated-grid case.
+    random = np.random.default_rng(657)
+    eps = 1e-10
+    n = jax.device_count()
+    num_source = 20
+    num_target = 32 * n
+
+    x = [jnp.asarray(random.uniform(-1.0, 1.0, size=num_source)) for _ in range(ndim)]
+    s = [jnp.asarray(random.uniform(-1.0, 1.0, size=num_target)) for _ in range(ndim)]
+    c = jnp.asarray(
+        random.normal(size=num_source) + 1j * random.normal(size=num_source)
+    )
+    target = jnp.asarray(
+        random.normal(size=num_target) + 1j * random.normal(size=num_target)
+    )
+
+    with enable_x64():
+        mesh = _mesh()
+        rows = NamedSharding(mesh, P("s"))
+        repl = NamedSharding(mesh, P())
+        xs = [jax.device_put(xi, repl) for xi in x]  # sources replicated
+        ss = [jax.device_put(si, rows) for si in s]  # targets sharded
+        tgt = jax.device_put(target, rows)  # target data sharded
+
+        def single(c):
+            f = nufft3(c, *x, *s, iflag=iflag, eps=eps)
+            return jnp.sum(jnp.abs(f - target) ** 2)
+
+        def local(c, *pts_and_tgt):
+            xp = pts_and_tgt[:ndim]
+            sp = pts_and_tgt[ndim : 2 * ndim]
+            tg = pts_and_tgt[2 * ndim]
+            f = nufft3(
+                c, *xp, *sp, iflag=iflag, eps=eps
+            )  # all sources -> local targets
+            return jax.lax.psum(jnp.sum(jnp.abs(f - tg) ** 2), "s")
+
+        sm = shard_map(
+            local,
+            mesh=mesh,
+            in_specs=(P(),) + (P(),) * ndim + (P("s"),) * ndim + (P("s"),),
+            out_specs=P(),
+        )
+
+        _check(
+            single=single,
+            sharded=lambda c: sm(c, *xs, *ss, tgt),
+            primal=c,
+            primal_spec=P(),
+            mesh=mesh,
+        )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="sharding type-3 on sources and targets simultaneously not supported",
+)
+def test_nufft3_shard_map_shard_source_and_target():
+    # NOT a valid data-parallel pattern for the type-3 transform: with
+    # both point sets sharded, each device computes only its local sources'
+    # contribution to its local targets, so the forward result is wrong.
+    # Kept as xfail to (1) document the limitation, (2) check that we're
+    # correctly blocking this execution, and (3) leave it as a breadcrumb
+    # for future work.
+    ndim, iflag = 2, -1
+    random = np.random.default_rng(657)
+    eps = 1e-10
+    n = jax.device_count()
+    num_source = 32 * n
+    num_target = 32 * n
+
+    x = [jnp.asarray(random.uniform(-1.0, 1.0, size=num_source)) for _ in range(ndim)]
+    s = [jnp.asarray(random.uniform(-1.0, 1.0, size=num_target)) for _ in range(ndim)]
+    c = jnp.asarray(
+        random.normal(size=num_source) + 1j * random.normal(size=num_source)
+    )
+
+    with enable_x64():
+        mesh = _mesh()
+        rows = NamedSharding(mesh, P("s"))
+        cs = jax.device_put(c, rows)
+        xs = [jax.device_put(xi, rows) for xi in x]
+        ss = [jax.device_put(si, rows) for si in s]
+
+        def local(c, *pts):
+            xp, sp = pts[:ndim], pts[ndim:]
+            return nufft3(c, *xp, *sp, iflag=iflag, eps=eps)
+
+        sm = shard_map(
+            local,
+            mesh=mesh,
+            in_specs=(P("s"),) + (P("s"),) * ndim + (P("s"),) * ndim,
+            out_specs=P("s"),
+        )
+
+        f_sharded = sm(cs, *xs, *ss)
+        f_ref = nufft3(c, *x, *s, iflag=iflag, eps=eps)
+        check_close(f_sharded, f_ref)  # missing cross-shard source contributions

--- a/tests/sharding_test.py
+++ b/tests/sharding_test.py
@@ -10,6 +10,8 @@ varying manual axes (vma) or registers a rep rule. Without it the forward is
 correct but the gradient is silently wrong.
 """
 
+import os
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -42,8 +44,18 @@ else:
     enable_x64 = jax.enable_x64
 
 
-# All tests in this module need a multi-device mesh.
-pytestmark = pytest.mark.skipif(jax.device_count() < 2, reason="requires >=2 devices")
+# CI uses JAX_FINUFFT_REQUIRE_SHARDING to ensure the tests are not skipped
+_MIN_DEVICES = 2
+if jax.device_count() < _MIN_DEVICES and os.environ.get("JAX_FINUFFT_REQUIRE_SHARDING"):
+    raise RuntimeError(
+        f"JAX_FINUFFT_REQUIRE_SHARDING is set, but only {jax.device_count()} "
+        f"device(s) are available; the sharding tests need >= {_MIN_DEVICES}."
+    )
+pytestmark = pytest.mark.skipif(
+    jax.device_count() < _MIN_DEVICES,
+    reason=f"requires >= {_MIN_DEVICES} devices "
+    "(set JAX_FINUFFT_REQUIRE_SHARDING to make this an error instead)",
+)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/sharding_test.py
+++ b/tests/sharding_test.py
@@ -66,8 +66,7 @@ def _enable_x64():
 
 
 def _mesh():
-    # Plain Mesh (Auto axis types); shard_map then enters manual mode. Avoid
-    # jax.make_mesh, which now defaults to Explicit axes (sharding-in-types).
+    # Plain Mesh (Auto axis types); shard_map then enters manual mode.
     return jax.sharding.Mesh(np.array(jax.devices()), ("s",))
 
 
@@ -77,8 +76,8 @@ def _check(single, sharded, primal, primal_spec, mesh):
     v0, g0 = jax.value_and_grad(single)(primal)
     primal = jax.device_put(primal, NamedSharding(mesh, primal_spec))
     v1, g1 = jax.value_and_grad(sharded)(primal)
-    check_close(v1, v0)  # forward (correct even without the fix)
-    check_close(g1, g0)  # gradient (wrong without the fix)
+    check_close(v1, v0)  # forward
+    check_close(g1, g0)  # gradient
 
 
 @pytest.mark.parametrize("ndim", [1, 2, 3])
@@ -298,9 +297,8 @@ def test_nufft3_shard_map_shard_source_and_target():
     # NOT a valid data-parallel pattern for the type-3 transform: with
     # both point sets sharded, each device computes only its local sources'
     # contribution to its local targets, so the forward result is wrong.
-    # Kept as xfail to (1) document the limitation, (2) check that we're
-    # correctly blocking this execution, and (3) leave it as a breadcrumb
-    # for future work.
+    # Kept as xfail to (1) document the limitation, and (2) leave it as a
+    # breadcrumb for future work.
     ndim = 2
     random = np.random.default_rng(657)
     eps = 1e-10

--- a/tests/sharding_test.py
+++ b/tests/sharding_test.py
@@ -1,0 +1,216 @@
+"""Correctness of the NUFFT transforms under ``jax.shard_map``.
+
+These tests exercise the data-parallel patterns over the nonuniform
+points: the points (and coefficients) are sharded across the mesh while the
+uniform grid is replicated, and the result is reduced across devices with
+``jax.lax.psum``. The forward transform shards trivially -- each device runs a
+local transform on its slice of points -- but the gradient of a *replicated*
+input requires a cross-device ``psum`` that is only inserted when JAX tracks
+varying manual axes (vma), i.e. jax >= 0.6.0. Without it the forward is
+correct but the gradient is silently wrong.
+"""
+
+from itertools import product
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax._src import test_util as jtu
+from jax.sharding import NamedSharding, PartitionSpec as P
+
+from jax_finufft import nufft1, nufft2, nufft3
+
+# Must run before the backend is initialized, so keep it at import time.
+jtu.request_cpu_devices(2)
+
+try:
+    from jax import shard_map  # jax >= 0.10
+except ImportError:
+    from jax.experimental.shard_map import shard_map
+
+
+def check_close(a, b, **kwargs):
+    kwargs["rtol"] = kwargs.get("rtol", {"complex128": 1e-7, "complex64": 1e-4})
+    return jtu.check_close(a, b, **kwargs)
+
+
+if jax.version.__version_info__ < (0, 8, 0):
+    enable_x64 = jax.experimental.enable_x64
+else:
+    enable_x64 = jax.enable_x64
+
+
+# All tests in this module need a multi-device mesh.
+pytestmark = pytest.mark.skipif(jax.device_count() < 2, reason="requires >=2 devices")
+
+
+def _mesh():
+    # Plain Mesh (Auto axis types); shard_map then enters manual mode. Avoid
+    # jax.make_mesh, which now defaults to Explicit axes (sharding-in-types).
+    return jax.sharding.Mesh(np.array(jax.devices()), ("s",))
+
+
+def _check(single, sharded, primal, primal_spec, mesh):
+    """Compare value_and_grad of a single-device loss against its shard_map'd
+    counterpart, differentiating with respect to ``primal``."""
+    v0, g0 = jax.value_and_grad(single)(primal)
+    primal = jax.device_put(primal, NamedSharding(mesh, primal_spec))
+    v1, g1 = jax.value_and_grad(sharded)(primal)
+    check_close(v1, v0)  # forward (correct even without the fix)
+    check_close(g1, g0)  # gradient (wrong without the fix)
+
+
+@pytest.mark.parametrize("ndim, iflag", product([1, 2, 3], [-1, 1]))
+def test_nufft2_shard_map_grad(ndim, iflag):
+    # Data-parallel type 2: grid replicated, points + data sharded (the #226 repro).
+    # Differentiate w.r.t. the *replicated* grid -- this is the reported bug.
+    random = np.random.default_rng(657)
+    eps = 1e-10
+    n = jax.device_count()
+    num_nonuniform = 32 * n
+    num_uniform = tuple(4 + np.arange(ndim))
+
+    x = [
+        jnp.asarray(random.uniform(-np.pi, np.pi, size=num_nonuniform))
+        for _ in range(ndim)
+    ]
+    grid = jnp.asarray(
+        random.normal(size=num_uniform) + 1j * random.normal(size=num_uniform)
+    )
+    data = jnp.asarray(
+        random.normal(size=num_nonuniform) + 1j * random.normal(size=num_nonuniform)
+    )
+
+    def chi(g, *pts, d):
+        return jnp.sum(jnp.abs(nufft2(g, *pts, iflag=iflag, eps=eps) - d) ** 2)
+
+    with enable_x64():
+        mesh = _mesh()
+        rows = NamedSharding(mesh, P("s"))
+        xs = [jax.device_put(xi, rows) for xi in x]
+        ds = jax.device_put(data, rows)
+
+        def local(g, *pts_and_data):
+            *pts, d = pts_and_data
+            return jax.lax.psum(chi(g, *pts, d=d), "s")
+
+        sm = shard_map(
+            local,
+            mesh=mesh,
+            in_specs=(P(),) + (P("s"),) * (ndim + 1),
+            out_specs=P(),
+        )
+
+        _check(
+            single=lambda g: chi(g, *x, d=data),
+            sharded=lambda g: sm(g, *xs, ds),
+            primal=grid,
+            primal_spec=P(),
+            mesh=mesh,
+        )
+
+
+@pytest.mark.parametrize("ndim, iflag", product([1, 2, 3], [-1, 1]))
+def test_nufft1_shard_map_grad(ndim, iflag):
+    # Data-parallel type 1: coeffs + points sharded; the type-1 sum over points is
+    # additive across shards, so the local results are combined with psum. The
+    # transpose of type 1 is a replicated->sharded type 2, exercising the vma path
+    # in the reverse direction. Differentiate w.r.t. the sharded coeffs.
+    random = np.random.default_rng(657)
+    eps = 1e-10
+    n = jax.device_count()
+    num_nonuniform = 32 * n
+    num_uniform = tuple(4 + np.arange(ndim))
+
+    x = [
+        jnp.asarray(random.uniform(-np.pi, np.pi, size=num_nonuniform))
+        for _ in range(ndim)
+    ]
+    c = jnp.asarray(
+        random.normal(size=num_nonuniform) + 1j * random.normal(size=num_nonuniform)
+    )
+    target = jnp.asarray(
+        random.normal(size=num_uniform) + 1j * random.normal(size=num_uniform)
+    )
+
+    with enable_x64():
+        mesh = _mesh()
+        rows = NamedSharding(mesh, P("s"))
+        xs = [jax.device_put(xi, rows) for xi in x]
+
+        def single(c):
+            f = nufft1(num_uniform, c, *x, iflag=iflag, eps=eps)
+            return jnp.sum(jnp.abs(f - target) ** 2)
+
+        def local(c, *pts):
+            f = jax.lax.psum(nufft1(num_uniform, c, *pts, iflag=iflag, eps=eps), "s")
+            return jnp.sum(jnp.abs(f - target) ** 2)
+
+        sm = shard_map(
+            local,
+            mesh=mesh,
+            in_specs=(P("s"),) * (ndim + 1),
+            out_specs=P(),
+        )
+
+        _check(
+            single=single,
+            sharded=lambda c: sm(c, *xs),
+            primal=c,
+            primal_spec=P("s"),
+            mesh=mesh,
+        )
+
+
+@pytest.mark.parametrize("ndim, iflag", product([1, 2, 3], [-1, 1]))
+def test_nufft3_shard_map_grad(ndim, iflag):
+    # Data-parallel type 3: source coeffs + source points sharded, target points
+    # replicated. Each shard contributes all targets; combined with psum. The
+    # replicated target points force a pvary up to the sharded axis inside the
+    # transform. Differentiate w.r.t. the sharded coeffs.
+    random = np.random.default_rng(657)
+    eps = 1e-10
+    n = jax.device_count()
+    num_source = 32 * n
+    num_target = 20
+
+    x = [jnp.asarray(random.uniform(-1.0, 1.0, size=num_source)) for _ in range(ndim)]
+    s = [jnp.asarray(random.uniform(-1.0, 1.0, size=num_target)) for _ in range(ndim)]
+    c = jnp.asarray(
+        random.normal(size=num_source) + 1j * random.normal(size=num_source)
+    )
+    target = jnp.asarray(
+        random.normal(size=num_target) + 1j * random.normal(size=num_target)
+    )
+
+    with enable_x64():
+        mesh = _mesh()
+        rows = NamedSharding(mesh, P("s"))
+        repl = NamedSharding(mesh, P())
+        xs = [jax.device_put(xi, rows) for xi in x]
+        ss = [jax.device_put(si, repl) for si in s]
+
+        def single(c):
+            f = nufft3(c, *x, *s, iflag=iflag, eps=eps)
+            return jnp.sum(jnp.abs(f - target) ** 2)
+
+        def local(c, *pts):
+            xp, sp = pts[:ndim], pts[ndim:]
+            f = jax.lax.psum(nufft3(c, *xp, *sp, iflag=iflag, eps=eps), "s")
+            return jnp.sum(jnp.abs(f - target) ** 2)
+
+        sm = shard_map(
+            local,
+            mesh=mesh,
+            in_specs=(P("s"),) + (P("s"),) * ndim + (P(),) * ndim,
+            out_specs=P(),
+        )
+
+        _check(
+            single=single,
+            sharded=lambda c: sm(c, *xs, *ss),
+            primal=c,
+            primal_spec=P("s"),
+            mesh=mesh,
+        )

--- a/tests/sharding_test.py
+++ b/tests/sharding_test.py
@@ -10,8 +10,6 @@ varying manual axes (vma) or registers a rep rule. Without it the forward is
 correct but the gradient is silently wrong.
 """
 
-from itertools import product
-
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -61,8 +59,8 @@ def _check(single, sharded, primal, primal_spec, mesh):
     check_close(g1, g0)  # gradient (wrong without the fix)
 
 
-@pytest.mark.parametrize("ndim, iflag", product([1, 2, 3], [-1, 1]))
-def test_nufft2_shard_map_grad(ndim, iflag):
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_nufft2_shard_map_grad(ndim):
     # Data-parallel type 2: grid replicated, points + data sharded (the #226 repro).
     # Differentiate w.r.t. the *replicated* grid -- this is the reported bug.
     random = np.random.default_rng(657)
@@ -83,7 +81,7 @@ def test_nufft2_shard_map_grad(ndim, iflag):
     )
 
     def chi(g, *pts, d):
-        return jnp.sum(jnp.abs(nufft2(g, *pts, iflag=iflag, eps=eps) - d) ** 2)
+        return jnp.sum(jnp.abs(nufft2(g, *pts, eps=eps) - d) ** 2)
 
     with enable_x64():
         mesh = _mesh()
@@ -111,8 +109,8 @@ def test_nufft2_shard_map_grad(ndim, iflag):
         )
 
 
-@pytest.mark.parametrize("ndim, iflag", product([1, 2, 3], [-1, 1]))
-def test_nufft1_shard_map_grad(ndim, iflag):
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_nufft1_shard_map_grad(ndim):
     # Data-parallel type 1: coeffs + points sharded; the type-1 sum over points is
     # additive across shards, so the local results are combined with psum. The
     # transpose of type 1 is a replicated->sharded type 2, exercising the vma path
@@ -140,11 +138,11 @@ def test_nufft1_shard_map_grad(ndim, iflag):
         xs = [jax.device_put(xi, rows) for xi in x]
 
         def single(c):
-            f = nufft1(num_uniform, c, *x, iflag=iflag, eps=eps)
+            f = nufft1(num_uniform, c, *x, eps=eps)
             return jnp.sum(jnp.abs(f - target) ** 2)
 
         def local(c, *pts):
-            f = jax.lax.psum(nufft1(num_uniform, c, *pts, iflag=iflag, eps=eps), "s")
+            f = jax.lax.psum(nufft1(num_uniform, c, *pts, eps=eps), "s")
             return jnp.sum(jnp.abs(f - target) ** 2)
 
         sm = shard_map(
@@ -163,8 +161,8 @@ def test_nufft1_shard_map_grad(ndim, iflag):
         )
 
 
-@pytest.mark.parametrize("ndim, iflag", product([1, 2, 3], [-1, 1]))
-def test_nufft3_shard_map_grad(ndim, iflag):
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_nufft3_shard_map_grad(ndim):
     # Data-parallel type 3: source coeffs + source points sharded, target points
     # replicated. Each shard contributes all targets; combined with psum. The
     # replicated target points force a pvary up to the sharded axis inside the
@@ -192,12 +190,12 @@ def test_nufft3_shard_map_grad(ndim, iflag):
         ss = [jax.device_put(si, repl) for si in s]
 
         def single(c):
-            f = nufft3(c, *x, *s, iflag=iflag, eps=eps)
+            f = nufft3(c, *x, *s, eps=eps)
             return jnp.sum(jnp.abs(f - target) ** 2)
 
         def local(c, *pts):
             xp, sp = pts[:ndim], pts[ndim:]
-            f = jax.lax.psum(nufft3(c, *xp, *sp, iflag=iflag, eps=eps), "s")
+            f = jax.lax.psum(nufft3(c, *xp, *sp, eps=eps), "s")
             return jnp.sum(jnp.abs(f - target) ** 2)
 
         sm = shard_map(
@@ -216,8 +214,8 @@ def test_nufft3_shard_map_grad(ndim, iflag):
         )
 
 
-@pytest.mark.parametrize("ndim, iflag", product([1, 2, 3], [-1, 1]))
-def test_nufft3_shard_map_grad_rep_source_shard_target(ndim, iflag):
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_nufft3_shard_map_grad_rep_source_shard_target(ndim):
     # Data-parallel type 3, complementary pattern: source coeffs + source points
     # replicated, target points (and the loss) sharded. Each device evaluates all
     # sources at its slice of targets, so no forward collective is needed.
@@ -248,16 +246,14 @@ def test_nufft3_shard_map_grad_rep_source_shard_target(ndim, iflag):
         tgt = jax.device_put(target, rows)  # target data sharded
 
         def single(c):
-            f = nufft3(c, *x, *s, iflag=iflag, eps=eps)
+            f = nufft3(c, *x, *s, eps=eps)
             return jnp.sum(jnp.abs(f - target) ** 2)
 
         def local(c, *pts_and_tgt):
             xp = pts_and_tgt[:ndim]
             sp = pts_and_tgt[ndim : 2 * ndim]
             tg = pts_and_tgt[2 * ndim]
-            f = nufft3(
-                c, *xp, *sp, iflag=iflag, eps=eps
-            )  # all sources -> local targets
+            f = nufft3(c, *xp, *sp, eps=eps)  # all sources -> local targets
             return jax.lax.psum(jnp.sum(jnp.abs(f - tg) ** 2), "s")
 
         sm = shard_map(
@@ -287,7 +283,7 @@ def test_nufft3_shard_map_shard_source_and_target():
     # Kept as xfail to (1) document the limitation, (2) check that we're
     # correctly blocking this execution, and (3) leave it as a breadcrumb
     # for future work.
-    ndim, iflag = 2, -1
+    ndim = 2
     random = np.random.default_rng(657)
     eps = 1e-10
     n = jax.device_count()
@@ -309,7 +305,7 @@ def test_nufft3_shard_map_shard_source_and_target():
 
         def local(c, *pts):
             xp, sp = pts[:ndim], pts[ndim:]
-            return nufft3(c, *xp, *sp, iflag=iflag, eps=eps)
+            return nufft3(c, *xp, *sp, eps=eps)
 
         sm = shard_map(
             local,
@@ -319,5 +315,5 @@ def test_nufft3_shard_map_shard_source_and_target():
         )
 
         f_sharded = sm(cs, *xs, *ss)
-        f_ref = nufft3(c, *x, *s, iflag=iflag, eps=eps)
+        f_ref = nufft3(c, *x, *s, eps=eps)
         check_close(f_sharded, f_ref)  # missing cross-shard source contributions


### PR DESCRIPTION
Adds support for manual-mode sharding (`shard_map`) by adding VMA info to the replicated inputs with `auto_insert_reshard`, or the equivalent in older JAX versions. This inserts the cross-device sums that were missing before.

The supported shardings are documented in the readme, but one limitation is that only the non-uniform points, not the uniform grid, can be sharded. This is because the local finufft call expects to see the whole uniform grid.

Fixes #226.